### PR TITLE
Default to using Mix.Project to find the root path

### DIFF
--- a/lib/exrm_deb/utils/config.ex
+++ b/lib/exrm_deb/utils/config.ex
@@ -30,7 +30,13 @@ defmodule ExrmDeb.Utils.Config do
   in the library (such as templates)
   """
   def root do
-    Application.get_env(:exrm_deb, :root)
+    Mix.Project.deps_paths
+    |> Map.fetch(:exrm_deb)
+    |> case do
+         {:ok, path} -> path
+         :error      -> # We're trying to build ourself!?
+           Application.get_env(:exrm_deb, :root)
+    end
   end
 
 end

--- a/lib/mix/tasks/release.deb.generate_templates.ex
+++ b/lib/mix/tasks/release.deb.generate_templates.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Release.Deb.GenerateTemplates do
     {:ok, _} =
       [ExrmDeb.Utils.Config.root, "templates"]
       |> Path.join
-      |> File.cp_r(dest, fn(source, destination) ->
+      |> File.cp_r(dest, fn(_source, destination) ->
         IO.gets("Overwriting #{destination |> Path.basename }. Type y to confirm: ") == "y\n"
       end)
   end


### PR DESCRIPTION
If not, fallback to using the config.ex's root.

Fixes #6
