### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,8 +30,8 @@ defmodule ExrmDeb.Mixfile do
 
   defp deps(:test) do
     deps(:all) ++ [
-      {:faker, "~> 0.6"},
-      {:excoveralls, "~> 0.4"},
+      {:faker, "~> 0.6", only: :test},
+      {:excoveralls, "~> 0.4", only: :test},
     ]
   end
 
@@ -43,8 +43,8 @@ defmodule ExrmDeb.Mixfile do
 
   defp deps(:dev) do
     deps(:all) ++ [
-      {:ex_doc, "~> 0.11"},
-      {:earmark, "~> 0.2"}
+      {:ex_doc, "~> 0.11", only: :dev},
+      {:earmark, "~> 0.2", only: :dev}
     ]
   end
 


### PR DESCRIPTION
Previous configuration caused exrm_deb to depend on ex_doc and
earmark at runtime, which is not needed.

Fixes #10 

---

I'm not 100% sure of this, so please check this. Running `mix hex.publish` without actually going through should list dependencies that will be included.
