### PR TITLE
use erl_tar instead of system (g)tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Adds simple [Debian Package][1] (DEB) generation to the exrm package manager.
 
 Before using exrm-deb, you'll need the following commands installed and in your path:
 
- - `tar` (or `gtar` if you're on mac - you can `brew install gnu-tar` if you don't already have it)
  - `ar`
  - `uname`
 

--- a/lib/exrm_deb/data.ex
+++ b/lib/exrm_deb/data.ex
@@ -19,8 +19,7 @@ defmodule ExrmDeb.Data do
 
     ExrmDeb.Utils.Compression.compress(
       data_dir,
-      Path.join([data_dir, "..", "data.tar.gz"]),
-      owner: config.owner
+      Path.join([data_dir, "..", "data.tar.gz"])
     )
     ExrmDeb.Utils.File.remove_tmp(data_dir)
 

--- a/lib/exrm_deb/data.ex
+++ b/lib/exrm_deb/data.ex
@@ -19,7 +19,8 @@ defmodule ExrmDeb.Data do
 
     ExrmDeb.Utils.Compression.compress(
       data_dir,
-      Path.join([data_dir, "..", "data.tar.gz"])
+      Path.join([data_dir, "..", "data.tar.gz"]),
+      fakeroot: true
     )
     ExrmDeb.Utils.File.remove_tmp(data_dir)
 

--- a/lib/exrm_deb/utils/file.ex
+++ b/lib/exrm_deb/utils/file.ex
@@ -51,4 +51,26 @@ defmodule ExrmDeb.Utils.File do
     {:ok, _files} = File.rm_rf(dir)
   end
 
+  @doc """
+  List all files recursively
+  """
+  def ls_r(path \\ ".") do
+    do_ls_r(path, path)
+  end
+
+  defp do_ls_r(init_path, path, acc \\ []) do
+    path
+    |> File.ls!
+    |> Enum.reduce(acc, fn(new_path, acc) ->
+      new_path = Path.join(path, new_path)
+
+      new_path
+      |> File.dir?
+      |> case do
+        true -> do_ls_r(init_path, new_path, acc)
+        _ -> [Path.relative_to(new_path, init_path) | acc]
+      end
+    end)
+  end
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExrmDeb.Mixfile do
   end
 
   defp apps(_) do
-    [:logger, :exrm, :timex, :vex]
+    [:logger, :exrm, :timex, :vex, :swab]
   end
 
   defp deps(:test) do
@@ -52,7 +52,8 @@ defmodule ExrmDeb.Mixfile do
     [
      {:exrm, "~> 1.0"},
      {:timex, "~> 1.0"},
-     {:vex, "~> 0.5"}
+     {:vex, "~> 0.5"},
+     {:swab, github: "crownedgrouse/swab", branch: "master"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -19,6 +19,7 @@
   "providers": {:hex, :providers, "1.6.0"},
   "relx": {:hex, :relx, "3.18.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
+  "swab": {:git, "https://github.com/crownedgrouse/swab.git", "1610c706d07c82a9c8f6129a8cb6a0e8ac8e6fcd", [branch: "master"]},
   "timex": {:hex, :timex, "1.0.1"},
   "tzdata": {:hex, :tzdata, "0.5.6"},
   "vex": {:hex, :vex, "0.5.5"}}


### PR DESCRIPTION
So here it is. Tests still run and the package still installs. With erl_tar it's not possible to set the owner so I've removed that.
