### PR TITLE
Fix systemd service file path

### DIFF
--- a/lib/exrm_deb/generators/systemd.ex
+++ b/lib/exrm_deb/generators/systemd.ex
@@ -16,7 +16,7 @@ defmodule ExrmDeb.Generators.Systemd do
       ])
 
     out_dir =
-      [data_dir, "etc", "systemd", "system", "multi-user.target.wants"]
+      [data_dir, "lib", "systemd", "system"]
       |> Path.join
 
     :ok = File.mkdir_p(out_dir)


### PR DESCRIPTION
Service files belong in `/lib/systemd/system` and are symlinked somewhere in `/etc/systemd/system/` when running `systemctl enable <serviceName>.service` (depending on what's in the `WantedBy` entry of the service file). More info over here: https://wiki.debian.org/Teams/pkg-systemd/Packaging#systemd_unit_files_naming_and_installation

When I tried installing the deb file exrm_deb outputted it wasn't working on a debian 8 installation using systemd, so I think this will make things closer to being right. The one thing I'm not totally sure about is if it'll automatically get enabled after installation (haven't worked too much with debian packages, so working somewhat blindly)
